### PR TITLE
Variable column width

### DIFF
--- a/bin/leo.py
+++ b/bin/leo.py
@@ -168,24 +168,26 @@ def extracttext(element):
 
 
 def format_as_table(row):
-    # run through the rows once to find the maximum width to format correctly
-    translation_widths = [
-            len(extracttext(c1).strip())
-            for c1, c2
-            in [tr.getchildren() for tr in row]]
-    width = max(translation_widths)
-
-    # loop again, knowing the maximum translation width to do the actual formatting
+    widths = []
+    translations = []
     for tr in row:
         c1, c2 = tr.getchildren()
-        # print(c1,c2)
         t1 = extracttext(c1).strip()
         t2 = extracttext(c2)
         t1 = " ".join(t1.split())
-        print("{left:<{width}} | {right}".format(
+
+        widths.append(len(t1))
+        translations.append((t1, t2))
+
+    max_width = max(widths)
+    lines = [
+        "{left:<{width}} | {right}".format(
             left = t1,
-            width = width,
-            right = t2))
+            width = max_width,
+            right = t2)
+        for t1, t2 in translations
+    ]
+    print("\n".join(lines))
 
 
 def getResults(args, root):

--- a/bin/leo.py
+++ b/bin/leo.py
@@ -168,14 +168,24 @@ def extracttext(element):
 
 
 def format_as_table(row):
+    # run through the rows once to find the maximum width to format correctly
+    translation_widths = [
+            len(extracttext(c1).strip())
+            for c1, c2
+            in [tr.getchildren() for tr in row]]
+    width = max(translation_widths)
 
+    # loop again, knowing the maximum translation width to do the actual formatting
     for tr in row:
         c1, c2 = tr.getchildren()
         # print(c1,c2)
         t1 = extracttext(c1).strip()
         t2 = extracttext(c2)
         t1 = " ".join(t1.split())
-        print("{:<55} | {}".format(t1, t2))
+        print("{left:<{width}} | {right}".format(
+            left = t1,
+            width = width,
+            right = t2))
 
 
 def getResults(args, root):


### PR DESCRIPTION
This matches the left column of the printed translation table to the width of the longest translation.
I currently can't think of an example in english, but while implementing #1, I found a very long translation for spanish:
```
$ leo -l es übersetzung

---------- Substantive ----------
la traducción                                           | die Übersetzung Pl.: die Übersetzungen
[...]
relación de transformación de un transformador de tensión [METR.] | Übersetzung eines Spannungswandlers
```

This is how the same table looks with variable width:
```
$ leo -l es übersetzung                  

---------- Substantive ----------
la traducción                                                        | die Übersetzung Pl.: die Übersetzungen
[...]
relación de transformación de un transformador de intensidad [METR.] | Übersetzung eines Stromwandlers
```

An additional nice side effect is that the tables for "short" tranlations are smaller now with increased readability. :)